### PR TITLE
Update MapLibreGlWrapper.ts

### DIFF
--- a/src/components/MapLibreMap/lib/MapLibreGlWrapper.ts
+++ b/src/components/MapLibreMap/lib/MapLibreGlWrapper.ts
@@ -12,6 +12,16 @@ import {
 	StyleImageMetadata,
 } from 'maplibre-gl';
 import { Map as MapType, Style } from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
+
+maplibregl.setRTLTextPlugin(
+	'https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.2.3/mapbox-gl-rtl-text.min.js',
+	(res) => {
+		console.log(res);
+	},
+	true // Lazy load the plugin
+);
+
 
 type WrapperEventArgArray = [string, (arg0: unknown) => void];
 type EventArgArray = [


### PR DESCRIPTION
- add plugin Mapbox Rtl

the map has an issue it rerenders Arabic words from left to right 

![beforeRtl](https://github.com/mapcomponents/react-map-components-maplibre/assets/82415612/264c4ae4-a526-4924-8ecf-07e845634f34)

I fixed it by adding an RTL plugin to maplibre using mapbox-style link 

![afterRtl](https://github.com/mapcomponents/react-map-components-maplibre/assets/82415612/fa09a803-4213-424f-9431-23d2ae975186)
