### PR TITLE
fix: incorrect property access

### DIFF
--- a/src/hooks/useSource.ts
+++ b/src/hooks/useSource.ts
@@ -28,7 +28,7 @@ function useSource(props: useSourceProps): useSourceType {
 
 	const removeSource = useCallback(() => {
 		if (mapHook.map && mapHook.map?.style?._layers) {
-			for (const [layerId, layer] of Object.entries(mapHook.map.map.style._layers)) {
+			for (const [layerId, layer] of Object.entries(mapHook.map.style._layers)) {
 				if (layer.source === sourceId.current) {
 					mapHook.map.removeLayer(layerId);
 				}


### PR DESCRIPTION
In the `if` above line 31 we check for `mapHook.map?.style?._layers` but below `mapHook.map.map.style._layers` is accessed. The latter is changed to the correct property to prevent a runtime error on cleanup.

Fixes #180. 