### PR TITLE
Upgrade to maplibre-gl 5.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [main]
+
+## Changed
+- Upgrade to maplibre to 5.6.0
+
 ## [v1.3.1]
 
 ## Changed

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"d3": "^7.9.0",
 		"globals": "^16.0.0",
 		"jspdf": "^3.0.1",
-		"maplibre-gl": "5.5.0",
+		"maplibre-gl": "5.6.0",
 		"osm2geojson-lite": "^1.0.3",
 		"pako": "^2.1.0",
 		"react-color": "^2.19.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2000,7 +2000,7 @@
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
-"@maplibre/maplibre-gl-style-spec@^23.2.2":
+"@maplibre/maplibre-gl-style-spec@^23.3.0":
   version "23.3.0"
   resolved "https://registry.yarnpkg.com/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-23.3.0.tgz#b69ab48cb3abead4e49213396c8f83492638b97c"
   integrity sha512-IGJtuBbaGzOUgODdBRg66p8stnwj9iDXkgbYKoYcNiiQmaez5WVRfXm4b03MCDwmZyX93csbfHFWEJJYHnn5oA==
@@ -10717,10 +10717,10 @@ mapbox-gl@*:
     tinyqueue "^3.0.0"
     vt-pbf "^3.1.3"
 
-maplibre-gl@5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-5.5.0.tgz#0a295a634e745a5c31848ac7198893da417d09ae"
-  integrity sha512-p8AOPuzzqn1ZA9gcXxKw0IED715we/2Owa/YUr6PANmgMvNMe/JG+V/C1hRra43Wm62Biz+Aa8AgbOLJimA8tA==
+maplibre-gl@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-5.6.0.tgz#bb62bad5669ecd33b27cd84d8d2338f93553d919"
+  integrity sha512-7TuHMozUC4rlIp08bSsxCixFn18P24otrlZU/7UGCO5RufFTJadFzauTrvBHr9FB67MbJ6nvFXEftGd0bUl4Iw==
   dependencies:
     "@mapbox/geojson-rewind" "^0.5.2"
     "@mapbox/jsonlint-lines-primitives" "^2.0.2"
@@ -10729,7 +10729,7 @@ maplibre-gl@5.5.0:
     "@mapbox/unitbezier" "^0.0.1"
     "@mapbox/vector-tile" "^1.3.1"
     "@mapbox/whoots-js" "^3.1.0"
-    "@maplibre/maplibre-gl-style-spec" "^23.2.2"
+    "@maplibre/maplibre-gl-style-spec" "^23.3.0"
     "@types/geojson" "^7946.0.16"
     "@types/geojson-vt" "3.2.5"
     "@types/mapbox__point-geometry" "^0.1.4"


### PR DESCRIPTION
For a complete list of what this version addresses (over 5.5.0) see https://github.com/maplibre/maplibre-gl-js/releases/tag/v5.6.0